### PR TITLE
Update es_id_ncbi(texto)

### DIFF
--- a/utils/prote_search.py
+++ b/utils/prote_search.py
@@ -22,7 +22,7 @@ def es_id_uniprot(texto):
 # Entrada = texto
 # Salida = booleano
 def es_id_ncbi(texto):
-    return bool(re.fullmatch(r"^[A-Z]{1,3}_?\d{5,9}(\.\d+)?$", texto))
+    return bool(re.fullmatch(r"^(NP|XP|YP|WP|ZP|AP)_\d{6,9}(\.\d+)?$", texto))
 
 
 # Formatea los resultados de UniProt en una tabla usando pandas


### PR DESCRIPTION
en la verificación si se trataba de uniprot o ncbi daba que si le pasabas un uniprot que empezaba con P lo reconocia como NCBI. al menos en los casos que yo vi. lo cambie y no me dio error, pero igual prueben lo tambien.